### PR TITLE
Switch to nix-pypi-fetcher-2

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -49,9 +49,9 @@ jobs:
         export MAX_MINUTES_WHEEL=30
         export MAX_MINUTES_SDIST=300
 
-        # avoid updating the lock file because this job's correct operation
-        # depends on the exact revisions in the committed lock file.
-        nix run --no-update-lock-file -L .#job-sdist-wheel
+        # avoid writing an updated lock file because this job's correct
+        # operation depends on the exact revisions in the committed lock file.
+        nix run --no-write-lock-file -L .#job-sdist-wheel
         git push
 
       shell: bash

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -49,7 +49,9 @@ jobs:
         export MAX_MINUTES_WHEEL=30
         export MAX_MINUTES_SDIST=300
 
-        nix run -L .#job-sdist-wheel
+        # avoid updating the lock file because this job's correct operation
+        # depends on the exact revisions in the committed lock file.
+        nix run --no-update-lock-file -L .#job-sdist-wheel
         git push
 
       shell: bash

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     mach-nix.url = "mach-nix";
     nixpkgs.url = "nixpkgs/nixos-unstable";
     nixpkgsPy36.url = "nixpkgs/b4db68ff563895eea6aab4ff24fa04ef403dfe14";
-    pypiIndex.url = "github:davhau/nix-pypi-fetcher";
+    pypiIndex.url = "github:davhau/nix-pypi-fetcher-2";
     pypiIndex.flake = false;
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -103,8 +103,14 @@
               set -e
               set -x
 
-              # update the index to get the newest packages
-              indexRevPrev=$(${pkgs.nixFlakes}/bin/nix flake metadata --json | ${pkgs.jq}/bin/jq -e --raw-output '.locks .nodes .pypiIndex .locked .rev')
+              # update the index to get the newest packages.
+              # don't let the lock file update yet because we need to capture
+              # the old value to compare against the new value after it does
+              # update.  often `nix flake metadata` won't try to update the
+              # lock file but if the definition of the source changed, it
+              # would without `--no-update-lock-file`.
+              indexRevPrev=$(${pkgs.nixFlakes}/bin/nix flake metadata --no-update-lock-file --json | ${pkgs.jq}/bin/jq -e --raw-output '.locks .nodes .pypiIndex .locked .rev')
+              # *now* let it update
               nix flake lock --update-input pypiIndex
               indexRev=$(${pkgs.nixFlakes}/bin/nix flake metadata --json | ${pkgs.jq}/bin/jq -e --raw-output '.locks .nodes .pypiIndex .locked .rev')
               if [ "$indexRevPrev" == "$indexRev" ]; then


### PR DESCRIPTION
nix-pypi-fetcher filled its GitHub storage quota and no longer receives updates.

Fixes #16 

I pushed a testing branch to my fork and uncovered a few bugs that way.  There is now an action running that looks like it has gotten past the hard parts of the change: https://github.com/PrivateStorageio/pypi-deps-db/actions/runs/3884330821

I suppose it will be several hours before it finishes.
