### PR TITLE
Pin nix in CI

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -22,7 +22,8 @@ jobs:
     - name: Install/Setup - NIX
       uses: cachix/install-nix-action@v18
       with:
-        nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8.tar.gz # nix 2.13.3
+        nix_path: nixpkgs=channel:nixos-unstable # no impact on nix in install-nix-action
+        install_url: https://releases.nixos.org/nix/nix-2.13.4/install
         # GC 30GB when free space < 3GB
         extra_nix_config: |
           experimental-features = nix-command flakes


### PR DESCRIPTION
(nix_path has no influence for nix installation but needs explicit install_url) last working nix version was 2.13.4 
- https://github.com/DavHau/pypi-deps-db/actions/runs/5130009856/jobs/9228253379

now pinned to nix 2.13.4